### PR TITLE
Server streaming RPCによる動画配信を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.mp4
+.DS_Store

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/Be3751/v-stream/internal/uni_stream_client"
+	"github.com/Be3751/v-stream/pkg/pb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func main() {
+	address := "localhost:8080"
+	conn, err := grpc.Dial(
+		address,
+
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	if err != nil {
+		log.Fatal("Connection failed.")
+		return
+	}
+	defer conn.Close()
+
+	client := pb.NewVideoStreamClient(conn)
+	myClient := uni_stream_client.NewMyClient(client)
+	myClient.RequestVideo(context.Background(), "_re")
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,7 +53,7 @@ func (s *myServer) ReceiveVideo(req *pb.VideoRequest, srv pb.VideoStream_Receive
 		return err
 	}
 	fmt.Println(root)
-	fileName := fmt.Sprintf("piyo%s.mp4", req.VideoId)
+	fileName := fmt.Sprintf("/media/in/piyo%s.mp4", req.VideoId)
 	f, err := os.Open(fmt.Sprintf("%s/%s", root, fileName))
 	if err != nil {
 		return fmt.Errorf("failed to open a file: %w", err)

--- a/internal/uni_stream_client/uni_stream.go
+++ b/internal/uni_stream_client/uni_stream.go
@@ -1,0 +1,65 @@
+package uni_stream_client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	vstream "github.com/Be3751/v-stream"
+	"github.com/Be3751/v-stream/pkg/pb"
+)
+
+type MyClient interface {
+	RequestVideo(ctx context.Context, videoId string)
+}
+
+var _ MyClient = (*myClient)(nil)
+
+type myClient struct {
+	vclient pb.VideoStreamClient
+}
+
+func NewMyClient(v pb.VideoStreamClient) MyClient {
+	return &myClient{vclient: v}
+}
+
+func (c *myClient) RequestVideo(ctx context.Context, videoId string) {
+	req := &pb.VideoRequest{
+		VideoId: videoId,
+	}
+	stream, err := c.vclient.ReceiveVideo(ctx, req)
+	if err != nil {
+		return
+	}
+
+	root, err := vstream.GetRootPath()
+	if err != nil {
+		return
+	}
+	fileName := "download.mp4"
+	f, err := os.Create(fmt.Sprintf("%s/media/out/%s", root, fileName))
+	if err != nil {
+		return
+	}
+
+	for {
+		res, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			fmt.Println("all the responses have already received.")
+			break
+		} else if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		_, err = f.Write(res.Video)
+		if err != nil {
+			return
+		}
+		fmt.Println(res)
+	}
+
+	return
+}


### PR DESCRIPTION
取り組んだ内容は以下の通り。
- リクエストに応じて動画をストリーミングするgRPCサーバーを実装
- RPCを実行してローカルに動画を保存するgRPCクライアントを実装

とりあえず動くレベルで実装できたので、諸々のリファクタリングを今後する。  
その次に、双方向ストリーミングを用いて、複数のクライアントに対して異なる動画をストリーミングするgRPCサーバーを実装する。